### PR TITLE
fix: sanitize blog slug to prevent path traversal, upgrade undici to 8.x

### DIFF
--- a/apps/web/src/lib/blog.ts
+++ b/apps/web/src/lib/blog.ts
@@ -66,7 +66,15 @@ export async function markdownToHTML(markdown: string) {
 }
 
 export async function getPost(slug: string) {
-  const filePath = path.join("content", `${slug}.mdx`);
+  // Sanitize slug to prevent path traversal: take only the filename component
+  const sanitizedSlug = path.basename(slug);
+  const filePath = path.join("content", `${sanitizedSlug}.mdx`);
+  // Verify the resolved path is still within the content directory
+  const contentDir = path.resolve(process.cwd(), "content");
+  const resolvedPath = path.resolve(process.cwd(), filePath);
+  if (!resolvedPath.startsWith(contentDir + path.sep)) {
+    throw new Error(`Invalid blog slug: ${slug}`);
+  }
   const source = fs.readFileSync(filePath, "utf-8");
   const { content: rawContent, data: metadata } = parseFrontmatter(source);
   const content = await markdownToHTML(rawContent);

--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "allsource-monorepo",
       "dependencies": {
-        "undici": "^7.24.6",
+        "undici": "^8.0.2",
       },
       "devDependencies": {
         "@biomejs/biome": "^2.3.13",
@@ -163,7 +163,7 @@
     },
     "sdks/typescript": {
       "name": "@allsource/client",
-      "version": "0.17.1",
+      "version": "0.17.3",
       "devDependencies": {
         "@types/bun": "^1.1.13",
         "typescript": "^6.0.2",
@@ -1311,7 +1311,7 @@
 
     "typescript": ["typescript@6.0.2", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ=="],
 
-    "undici": ["undici@7.24.6", "", {}, "sha512-Xi4agocCbRzt0yYMZGMA6ApD7gvtUFaxm4ZmeacWI4cZxaF6C+8I8QfofC20NAePiB/IcvZmzkJ7XPa471AEtA=="],
+    "undici": ["undici@8.0.2", "", {}, "sha512-B9MeU5wuFhkFAuNeA19K2GDFcQXZxq33fL0nRy2Aq30wdufZbyyvxW3/ChaeipXVfy/wUweZyzovQGk39+9k2w=="],
 
     "undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 

--- a/package.json
+++ b/package.json
@@ -32,6 +32,6 @@
   },
   "packageManager": "bun@1.1.29",
   "dependencies": {
-    "undici": "^7.24.6"
+    "undici": "^8.0.2"
   }
 }


### PR DESCRIPTION
## Summary

- **Security fix**: Sanitize the `slug` parameter in `getPost()` using `path.basename()` to strip any path traversal sequences (e.g. `../../../etc/passwd`), and verify the resolved path stays within the `content/` directory before reading the file.
- **Dependency upgrade**: Bump `undici` from `^7.24.6` to `^8.0.2` in the root `package.json` and regenerate the lockfile.

## Changes

- `apps/web/src/lib/blog.ts`: Added `path.basename()` sanitization and `contentDir` boundary check in `getPost()`
- `package.json`: Updated `undici` version to `^8.0.2`
- `bun.lock`: Regenerated after dependency upgrade

## Test plan

- [ ] Verify that a normal slug like `my-post` resolves correctly to `content/my-post.mdx`
- [ ] Verify that a malicious slug like `../../../etc/passwd` throws `Invalid blog slug` error
- [ ] Verify the build passes with the updated undici version